### PR TITLE
fix(climate, humidifier): mark entity unavailable when coordinator data is None (#63)

### DIFF
--- a/custom_components/duux/climate.py
+++ b/custom_components/duux/climate.py
@@ -135,17 +135,17 @@ class DuuxClimate(CoordinatorEntity, ClimateEntity):
     @property
     def current_temperature(self):
         """Return the current temperature."""
-        return self.coordinator.data.get("temp")
+        return (self.coordinator.data or {}).get("temp")
 
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return self.coordinator.data.get("sp")
+        return (self.coordinator.data or {}).get("sp")
 
     @property
     def hvac_mode(self):
         """Return current operation."""
-        power = self.coordinator.data.get("power", 0)
+        power = (self.coordinator.data or {}).get("power", 0)
         return HVACMode.HEAT if power == 1 else HVACMode.OFF
 
     @property
@@ -197,7 +197,10 @@ class DuuxClimate(CoordinatorEntity, ClimateEntity):
     @property
     def available(self):
         """Return if entity is available."""
-        return self.coordinator.last_update_success
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+        )
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
@@ -299,7 +302,7 @@ class DuuxClimateAutoDiscovery(DuuxClimate):
     @property
     def preset_mode(self):
         """Return current preset mode."""
-        mode = self.coordinator.data.get("mode")
+        mode = (self.coordinator.data or {}).get("mode")
         for preset in self._presets:
             if preset["value"] == str(mode):
                 return preset["name"]
@@ -392,7 +395,7 @@ class DuuxEdgeTwoClimate(DuuxClimate):
     @property
     def preset_mode(self):
         """Return current preset mode."""
-        mode = self.coordinator.data.get("heatin")
+        mode = (self.coordinator.data or {}).get("heatin")
         mode_map = {1: self.PRESET_LOW, 2: self.PRESET_HIGH, 3: self.PRESET_BOOST}
         return mode_map.get(mode, self.PRESET_LOW)
 
@@ -429,7 +432,7 @@ class DuuxEdgeClimate(DuuxClimate):
     @property
     def preset_mode(self):
         """Return current preset mode."""
-        mode = self.coordinator.data.get("heatin")
+        mode = (self.coordinator.data or {}).get("heatin")
         mode_map = {
             1: self.PRESET_LOW,
             2: self.PRESET_HIGH,

--- a/custom_components/duux/humidifier.py
+++ b/custom_components/duux/humidifier.py
@@ -112,24 +112,24 @@ class DuuxDehumidifier(CoordinatorEntity, HumidifierEntity):
     
     @property
     def is_on(self):
-        power = self.coordinator.data.get("power", 0)
+        power = (self.coordinator.data or {}).get("power", 0)
         return power == 1
-    
+
     @property
     def action(self):
         """Return current action."""
-        power = self.coordinator.data.get("power", 0)
+        power = (self.coordinator.data or {}).get("power", 0)
         return HumidifierAction.DRYING if power == 1 else HumidifierAction.OFF
-    
+
     @property
     def current_humidity(self):
         """Return the current humidity."""
-        return self.coordinator.data.get("hum")
-    
+        return (self.coordinator.data or {}).get("hum")
+
     @property
     def target_humidity(self):
         """Return the humidity we try to reach."""
-        return self.coordinator.data.get("sp")
+        return (self.coordinator.data or {}).get("sp")
     
     async def async_set_humidity(self, humidity: int):
         """Set new target humidity."""
@@ -146,7 +146,10 @@ class DuuxDehumidifier(CoordinatorEntity, HumidifierEntity):
     @property
     def available(self):
         """Return if entity is available."""
-        return self.coordinator.last_update_success
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+        )
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
@@ -180,7 +183,7 @@ class DuuxBoraDehumidifier(DuuxDehumidifier):
     @property
     def mode(self):
         """Return current preset mode."""
-        mode = self.coordinator.data.get("mode")
+        mode = (self.coordinator.data or {}).get("mode")
         mode_map = {
             0: self.PRESET_AUTO,
             1: self.PRESET_CONTINUOUS,

--- a/custom_components/duux/manifest.json
+++ b/custom_components/duux/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "requests>=2.31.0"
   ],
-  "version": "2.6.1"
+  "version": "2.6.2"
 }


### PR DESCRIPTION
Closes #63.

When the Duux device is physically powered off, `DataUpdateCoordinator.data` becomes `None` and the entities crash with `AttributeError: 'NoneType' object has no attribute 'get'` on every refresh, spamming the HA log (see issue #63 traceback pointing at `climate.py:148`).

This patch makes the entity report `available = False` while `coordinator.data is None`, so Home Assistant stops calling the state properties. Property accessors that may still run before HA picks up the new availability state (initial render, manual refreshes) now read through `(self.coordinator.data or {}).get(...)`, matching the pattern already used in `DuuxClimateAutoDiscovery.presets_discovery()` on line 225.

Fix applied to both `DuuxClimate` and `DuuxDehumidifier` since the same pattern is present in `humidifier.py` and would crash for the Bora dehumidifier under the same offline conditions. `manifest.json` bumped to `2.6.2` per CONTRIBUTING.

## Reproduction (against `master`)

```python
hvac_mode_old = lambda d: 'HEAT' if d.get('power', 0) == 1 else 'OFF'
hvac_mode_old(None)
# AttributeError: 'NoneType' object has no attribute 'get'
```

After the patch the same call returns `OFF` and the entity is marked unavailable until the device is back online.