### PR TITLE
Updated loglevel for authentication

### DIFF
--- a/custom_components/duux/duux_api.py
+++ b/custom_components/duux/duux_api.py
@@ -30,7 +30,7 @@ class DuuxAPI:
             self.token = data.get("token")
             if self.token:
                 self.session.headers.update({"Authorization": f"{self.token}"})
-                _LOGGER.warning("Successfully logged in to Duux API")
+                _LOGGER.info("Successfully logged in to Duux API")
                 return True
 
             _LOGGER.error("No token received from Duux API")


### PR DESCRIPTION
as reported in issue #59 there is a warning message for logging in to the API.

as this is the expected behavior this should not be an warning but an info logging, this PR changes the log level.