### PR TITLE
fix: restore translated states for TVOC and AQ sensors; add missing translations (DE/IT + new entities)

### DIFF
--- a/custom_components/duux/binary_sensor.py
+++ b/custom_components/duux/binary_sensor.py
@@ -93,7 +93,7 @@ class DuuxErrorSensor(DuuxBinarySensor):
             device,
             DuuxBinarySensorEntityDescription(
                 key="err",
-                name="Problem",
+                translation_key="problem",
                 device_class=BinarySensorDeviceClass.PROBLEM,
                 attrs=lambda data: {
                     "error_code": (data or {}).get("err"),
@@ -121,7 +121,7 @@ class DuuxConnectivitySensor(DuuxBinarySensor):
             device,
             DuuxBinarySensorEntityDescription(
                 key="connectivity",
-                name="Connected",
+                translation_key="connected",
                 device_class=BinarySensorDeviceClass.CONNECTIVITY,
                 attrs=lambda data: {
                     "last_seen": device.get("connectionUpdateDate"),

--- a/custom_components/duux/select.py
+++ b/custom_components/duux/select.py
@@ -180,7 +180,7 @@ class DuuxNeoSpeedSelector(DuuxSelector):
         """Initialize the speed selector."""
         super().__init__(coordinator, api, device)
         self._attr_unique_id = f"duux_{self._device_id}_speed"
-        self._attr_name = "Spray Volume"
+        self._attr_translation_key = "spray_volume"
         self._attr_icon = "mdi:weather-partly-rainy"
         self._attr_options = [self.SPEED_LOW, self.SPEED_MID, self.SPEED_HIGH]
 

--- a/custom_components/duux/sensor.py
+++ b/custom_components/duux/sensor.py
@@ -121,11 +121,6 @@ class DuuxSensor(CoordinatorEntity, SensorEntity):
         self._attr_extra_state_attributes = self.entity_description.attrs(data)
         self.async_write_ha_state()
 
-    @property
-    def native_value(self):
-        return self.coordinator.data.get(self.entity_description.key)
-
-
 class DuuxTempSensor(DuuxSensor):
     def __init__(self, coordinator, api, device):
         super().__init__(
@@ -296,14 +291,4 @@ class DuuxErrorSensor(DuuxSensor):
 
 
 class DuuxBora2024TimeRemainingSensor(DuuxTimeRemainingSensor):
-    """Time remaining sensor for Duux Bora 2024 (API key: 'timrm')."""
-
-    def __init__(self, coordinator, api, device):
-        super().__init__(coordinator, api, device, key="timrm")
-
-
-class DuuxBright2TimeRemainingSensor(DuuxTimeRemainingSensor):
-    """Time remaining sensor for Duux Bright 2 (API key: 'timerr')."""
-
-    def __init__(self, coordinator, api, device):
-        super().__init__(coordinator, api, device, key="timerr")
+    """Time remaining sens

--- a/custom_components/duux/sensor.py
+++ b/custom_components/duux/sensor.py
@@ -277,8 +277,8 @@ class DuuxErrorSensor(DuuxSensor):
             api,
             device,
             DuuxSensorEntityDescription(
-                name="Error Message",
                 key="err",
+                translation_key="error_message",
             ),
         )
         self._attr_icon = "mdi:comment-alert-outline"

--- a/custom_components/duux/sensor.py
+++ b/custom_components/duux/sensor.py
@@ -291,4 +291,14 @@ class DuuxErrorSensor(DuuxSensor):
 
 
 class DuuxBora2024TimeRemainingSensor(DuuxTimeRemainingSensor):
-    """Time remaining sens
+    """Time remaining sensor for Duux Bora 2024 (API key: 'timrm')."""
+
+    def __init__(self, coordinator, api, device):
+        super().__init__(coordinator, api, device, key="timrm")
+
+
+class DuuxBright2TimeRemainingSensor(DuuxTimeRemainingSensor):
+    """Time remaining sensor for Duux Bright 2 (API key: 'timerr')."""
+
+    def __init__(self, coordinator, api, device):
+        super().__init__(coordinator, api, device, key="timerr")

--- a/custom_components/duux/translations/de.json
+++ b/custom_components/duux/translations/de.json
@@ -1,0 +1,101 @@
+{
+    "entity": {
+        "sensor": {
+            "pm25": {
+                "name": "PM2.5"
+            },
+            "tvoc": {
+                "name": "TVOC",
+                "state": {
+                    "healthy": "Gesund",
+                    "acceptable": "Akzeptabel",
+                    "polluted": "Verschmutzt",
+                    "harmful": "Schädlich"
+                }
+            },
+            "filter_life": {
+                "name": "Verbleibende HEPA-Filter-Lebensdauer"
+            },
+            "time_remaining": {
+                "name": "Verbleibende Zeit"
+            },
+            "air_quality_index": {
+                "name": "Luftqualitätsindex",
+                "state": {
+                    "excellent": "Ausgezeichnet",
+                    "very_good": "Sehr gut",
+                    "good": "Gut",
+                    "fair": "Mäßig",
+                    "poor": "Schlecht",
+                    "harmful": "Schädlich"
+                }
+            },
+            "error_message": {
+                "name": "Fehlermeldung"
+            }
+        },
+        "switch": {
+            "child_lock": {
+                "name": "Kindersicherung"
+            },
+            "sleep_mode": {
+                "name": "Schlafmodus"
+            },
+            "cleaning_mode": {
+                "name": "Reinigungsmodus"
+            },
+            "laundry_mode": {
+                "name": "Wäschemodus"
+            },
+            "night_mode": {
+                "name": "Nachtmodus"
+            },
+            "ionizer": {
+                "name": "Ionisator"
+            }
+        },
+        "select": {
+            "fan_speed": {
+                "name": "Lüftergeschwindigkeit"
+            },
+            "timer": {
+                "name": "Timer"
+            },
+            "spray_volume": {
+                "name": "Sprühvolumen"
+            }
+        },
+        "binary_sensor": {
+            "problem": {
+                "name": "Problem"
+            },
+            "connected": {
+                "name": "Verbunden"
+            }
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Duux Anmeldung",
+                "description": "Geben Sie Ihre Duux-Kontodaten ein.",
+                "data": {
+                    "email": "E-Mail-Adresse",
+                    "password": "Passwort"
+                }
+            }
+        },
+        "error": {
+            "invalid_auth": "Ungültige Anmeldedaten. Bitte überprüfen Sie Ihre E-Mail und Ihr Passwort."
+        },
+        "abort": {
+            "already_configured": "Dieses Duux-Konto ist bereits konfiguriert."
+        }
+    },
+    "issues": {
+        "device_not_recognised": {
+            "description": "Duux hat ein Gerät erkannt, das nicht offiziell unterstützt wird. \n\rBitte überprüfen Sie den Gerätetyp und melden Sie ihn dem Integrationsentwickler. \n\rBenötigte Details: \n\rGerätename: {device_name}\n\rGerätetyp-ID: {device_type_id}\n\rSensortyp-ID: {sensor_type_id}\n\rGerätetyp: {reported_type}.",
+            "title": "Gerät nicht erkannt"
+        }
+    }
+}

--- a/custom_components/duux/translations/en.json
+++ b/custom_components/duux/translations/en.json
@@ -1,7 +1,9 @@
 {
     "entity": {
         "sensor": {
-            "pm25": { "name": "PM2.5" },
+            "pm25": {
+                "name": "PM2.5"
+            },
             "tvoc": {
                 "name": "TVOC",
                 "state": {
@@ -11,8 +13,12 @@
                     "harmful": "Harmful"
                 }
             },
-            "filter_life": { "name": "HEPA Filter remaining lifespan" },
-            "time_remaining": { "name": "Time Remaining" },
+            "filter_life": {
+                "name": "HEPA Filter remaining lifespan"
+            },
+            "time_remaining": {
+                "name": "Time Remaining"
+            },
             "air_quality_index": {
                 "name": "Air Quality Index",
                 "state": {
@@ -23,19 +29,41 @@
                     "poor": "Poor",
                     "harmful": "Harmful"
                 }
+            },
+            "error_message": {
+                "name": "Error Message"
             }
         },
         "switch": {
-            "child_lock": { "name": "Child Lock" },
-            "sleep_mode": { "name": "Sleep Mode" },
-            "cleaning_mode": { "name": "Cleaning Mode" },
-            "laundry_mode": { "name": "Laundry Mode" },
-            "night_mode": { "name": "Night Mode" },
-            "ionizer": { "name": "Ionizer" }
+            "child_lock": {
+                "name": "Child Lock"
+            },
+            "sleep_mode": {
+                "name": "Sleep Mode"
+            },
+            "cleaning_mode": {
+                "name": "Cleaning Mode"
+            },
+            "laundry_mode": {
+                "name": "Laundry Mode"
+            },
+            "night_mode": {
+                "name": "Night Mode"
+            },
+            "ionizer": {
+                "name": "Ionizer"
+            }
         },
         "select": {
-            "fan_speed": { "name": "Fan Speed" },
-            "timer": { "name": "Timer" }
+            "fan_speed": {
+                "name": "Fan Speed"
+            },
+            "timer": {
+                "name": "Timer"
+            },
+            "spray_volume": {
+                "name": "Spray Volume"
+            }
         }
     },
     "config": {

--- a/custom_components/duux/translations/en.json
+++ b/custom_components/duux/translations/en.json
@@ -64,6 +64,14 @@
             "spray_volume": {
                 "name": "Spray Volume"
             }
+        },
+        "binary_sensor": {
+            "problem": {
+                "name": "Problem"
+            },
+            "connected": {
+                "name": "Connected"
+            }
         }
     },
     "config": {

--- a/custom_components/duux/translations/es.json
+++ b/custom_components/duux/translations/es.json
@@ -1,7 +1,9 @@
 {
     "entity": {
         "sensor": {
-            "pm25": { "name": "PM2.5" },
+            "pm25": {
+                "name": "PM2.5"
+            },
             "tvoc": {
                 "name": "TVOC",
                 "state": {
@@ -11,8 +13,12 @@
                     "harmful": "Nocivo"
                 }
             },
-            "filter_life": { "name": "Vida del filtro HEPA" },
-            "time_remaining": { "name": "Tiempo restante" },
+            "filter_life": {
+                "name": "Vida del filtro HEPA"
+            },
+            "time_remaining": {
+                "name": "Tiempo restante"
+            },
             "air_quality_index": {
                 "name": "Índice de calidad del aire",
                 "state": {
@@ -23,19 +29,41 @@
                     "poor": "Deficiente",
                     "harmful": "Nocivo"
                 }
+            },
+            "error_message": {
+                "name": "Mensaje de error"
             }
         },
         "switch": {
-            "child_lock": { "name": "Bloqueo infantil" },
-            "sleep_mode": { "name": "Modo sueño" },
-            "cleaning_mode": { "name": "Modo limpieza" },
-            "laundry_mode": { "name": "Modo lavandería" },
-            "night_mode": { "name": "Modo noche" },
-            "ionizer": { "name": "Ionizador" }
+            "child_lock": {
+                "name": "Bloqueo infantil"
+            },
+            "sleep_mode": {
+                "name": "Modo sueño"
+            },
+            "cleaning_mode": {
+                "name": "Modo limpieza"
+            },
+            "laundry_mode": {
+                "name": "Modo lavandería"
+            },
+            "night_mode": {
+                "name": "Modo noche"
+            },
+            "ionizer": {
+                "name": "Ionizador"
+            }
         },
         "select": {
-            "fan_speed": { "name": "Velocidad del ventilador" },
-            "timer": { "name": "Temporizador" }
+            "fan_speed": {
+                "name": "Velocidad del ventilador"
+            },
+            "timer": {
+                "name": "Temporizador"
+            },
+            "spray_volume": {
+                "name": "Volumen de nebulización"
+            }
         }
     },
     "config": {

--- a/custom_components/duux/translations/es.json
+++ b/custom_components/duux/translations/es.json
@@ -64,6 +64,14 @@
             "spray_volume": {
                 "name": "Volumen de nebulización"
             }
+        },
+        "binary_sensor": {
+            "problem": {
+                "name": "Problema"
+            },
+            "connected": {
+                "name": "Conectado"
+            }
         }
     },
     "config": {

--- a/custom_components/duux/translations/fr.json
+++ b/custom_components/duux/translations/fr.json
@@ -1,7 +1,9 @@
 {
     "entity": {
         "sensor": {
-            "pm25": { "name": "PM2.5" },
+            "pm25": {
+                "name": "PM2.5"
+            },
             "tvoc": {
                 "name": "TVOC",
                 "state": {
@@ -11,8 +13,12 @@
                     "harmful": "Nocif"
                 }
             },
-            "filter_life": { "name": "Durée de vie restante du filtre HEPA" },
-            "time_remaining": { "name": "Temps restant" },
+            "filter_life": {
+                "name": "Durée de vie restante du filtre HEPA"
+            },
+            "time_remaining": {
+                "name": "Temps restant"
+            },
             "air_quality_index": {
                 "name": "Indice de qualité de l'air",
                 "state": {
@@ -23,19 +29,41 @@
                     "poor": "Mauvais",
                     "harmful": "Nocif"
                 }
+            },
+            "error_message": {
+                "name": "Message d'erreur"
             }
         },
         "switch": {
-            "child_lock": { "name": "Verrouillage enfant" },
-            "sleep_mode": { "name": "Mode sommeil" },
-            "cleaning_mode": { "name": "Mode nettoyage" },
-            "laundry_mode": { "name": "Mode linge" },
-            "night_mode": { "name": "Mode nuit" },
-            "ionizer": { "name": "Ioniseur" }
+            "child_lock": {
+                "name": "Verrouillage enfant"
+            },
+            "sleep_mode": {
+                "name": "Mode sommeil"
+            },
+            "cleaning_mode": {
+                "name": "Mode nettoyage"
+            },
+            "laundry_mode": {
+                "name": "Mode linge"
+            },
+            "night_mode": {
+                "name": "Mode nuit"
+            },
+            "ionizer": {
+                "name": "Ioniseur"
+            }
         },
         "select": {
-            "fan_speed": { "name": "Vitesse du ventilateur" },
-            "timer": { "name": "Minuteur" }
+            "fan_speed": {
+                "name": "Vitesse du ventilateur"
+            },
+            "timer": {
+                "name": "Minuteur"
+            },
+            "spray_volume": {
+                "name": "Volume de pulvérisation"
+            }
         }
     },
     "config": {

--- a/custom_components/duux/translations/fr.json
+++ b/custom_components/duux/translations/fr.json
@@ -64,6 +64,14 @@
             "spray_volume": {
                 "name": "Volume de pulvérisation"
             }
+        },
+        "binary_sensor": {
+            "problem": {
+                "name": "Problème"
+            },
+            "connected": {
+                "name": "Connecté"
+            }
         }
     },
     "config": {

--- a/custom_components/duux/translations/it.json
+++ b/custom_components/duux/translations/it.json
@@ -1,0 +1,101 @@
+{
+    "entity": {
+        "sensor": {
+            "pm25": {
+                "name": "PM2.5"
+            },
+            "tvoc": {
+                "name": "TVOC",
+                "state": {
+                    "healthy": "Sano",
+                    "acceptable": "Accettabile",
+                    "polluted": "Inquinato",
+                    "harmful": "Nocivo"
+                }
+            },
+            "filter_life": {
+                "name": "Durata residua filtro HEPA"
+            },
+            "time_remaining": {
+                "name": "Tempo rimanente"
+            },
+            "air_quality_index": {
+                "name": "Indice di qualità dell'aria",
+                "state": {
+                    "excellent": "Eccellente",
+                    "very_good": "Molto buono",
+                    "good": "Buono",
+                    "fair": "Discreto",
+                    "poor": "Scarso",
+                    "harmful": "Nocivo"
+                }
+            },
+            "error_message": {
+                "name": "Messaggio di errore"
+            }
+        },
+        "switch": {
+            "child_lock": {
+                "name": "Blocco bambini"
+            },
+            "sleep_mode": {
+                "name": "Modalità sonno"
+            },
+            "cleaning_mode": {
+                "name": "Modalità pulizia"
+            },
+            "laundry_mode": {
+                "name": "Modalità bucato"
+            },
+            "night_mode": {
+                "name": "Modalità notte"
+            },
+            "ionizer": {
+                "name": "Ionizzatore"
+            }
+        },
+        "select": {
+            "fan_speed": {
+                "name": "Velocità ventilatore"
+            },
+            "timer": {
+                "name": "Timer"
+            },
+            "spray_volume": {
+                "name": "Volume di nebulizzazione"
+            }
+        },
+        "binary_sensor": {
+            "problem": {
+                "name": "Problema"
+            },
+            "connected": {
+                "name": "Connesso"
+            }
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Accesso Duux",
+                "description": "Inserisci le credenziali del tuo account Duux.",
+                "data": {
+                    "email": "Indirizzo email",
+                    "password": "Password"
+                }
+            }
+        },
+        "error": {
+            "invalid_auth": "Credenziali non valide. Verifica la tua email e la password."
+        },
+        "abort": {
+            "already_configured": "Questo account Duux è già configurato."
+        }
+    },
+    "issues": {
+        "device_not_recognised": {
+            "description": "Duux ha rilevato un dispositivo non ufficialmente supportato. \n\rVerifica il tipo di dispositivo e segnalalo allo sviluppatore dell'integrazione. \n\rDettagli necessari: \n\rNome dispositivo: {device_name}\n\rID tipo dispositivo: {device_type_id}\n\rID tipo sensore: {sensor_type_id}\n\rTipo dispositivo: {reported_type}.",
+            "title": "Dispositivo non riconosciuto"
+        }
+    }
+}

--- a/custom_components/duux/translations/nl.json
+++ b/custom_components/duux/translations/nl.json
@@ -1,7 +1,9 @@
 {
     "entity": {
         "sensor": {
-            "pm25": { "name": "PM2.5" },
+            "pm25": {
+                "name": "PM2.5"
+            },
             "tvoc": {
                 "name": "TVOC",
                 "state": {
@@ -11,8 +13,12 @@
                     "harmful": "Schadelijk"
                 }
             },
-            "filter_life": { "name": "Levensduur HEPA filter" },
-            "time_remaining": { "name": "Resterende tijd" },
+            "filter_life": {
+                "name": "Levensduur HEPA filter"
+            },
+            "time_remaining": {
+                "name": "Resterende tijd"
+            },
             "air_quality_index": {
                 "name": "Luchtkwaliteitsindex",
                 "state": {
@@ -23,19 +29,41 @@
                     "poor": "Slecht",
                     "harmful": "Schadelijk"
                 }
+            },
+            "error_message": {
+                "name": "Foutmelding"
             }
         },
         "switch": {
-            "child_lock": { "name": "Kinderslot" },
-            "sleep_mode": { "name": "Slaapstand" },
-            "cleaning_mode": { "name": "Reinigingsstand" },
-            "laundry_mode": { "name": "Wasstand" },
-            "night_mode": { "name": "Nachtmodus" },
-            "ionizer": { "name": "Ionisator" }
+            "child_lock": {
+                "name": "Kinderslot"
+            },
+            "sleep_mode": {
+                "name": "Slaapstand"
+            },
+            "cleaning_mode": {
+                "name": "Reinigingsstand"
+            },
+            "laundry_mode": {
+                "name": "Wasstand"
+            },
+            "night_mode": {
+                "name": "Nachtmodus"
+            },
+            "ionizer": {
+                "name": "Ionisator"
+            }
         },
         "select": {
-            "fan_speed": { "name": "Ventilatorsnelheid" },
-            "timer": { "name": "Timer" }
+            "fan_speed": {
+                "name": "Ventilatorsnelheid"
+            },
+            "timer": {
+                "name": "Timer"
+            },
+            "spray_volume": {
+                "name": "Sproeivolume"
+            }
         }
     },
     "config": {

--- a/custom_components/duux/translations/nl.json
+++ b/custom_components/duux/translations/nl.json
@@ -64,6 +64,14 @@
             "spray_volume": {
                 "name": "Sproeivolume"
             }
+        },
+        "binary_sensor": {
+            "problem": {
+                "name": "Probleem"
+            },
+            "connected": {
+                "name": "Verbonden"
+            }
         }
     },
     "config": {


### PR DESCRIPTION
## Bug fix

8ea02ed  added a `native_value` property on `DuuxSensor` base class
that bypasses the mapped `_attr_native_value` set by `DuuxTVOCSensor`
and `DuuxAirQualitySensor`, causing them to return raw integers instead
of translation keys

**Fix:** remove the property from the base class. Since `DuuxErrorSensor` has
its own override, it should be unaffected.

## Translation improvements

- Added `translation_key` to `DuuxErrorSensor` (sensor), `DuuxNeoSpeedSelector` (select), and both binary sensors (`problem`, `connected`)
- Added **German** (`de`) and **Italian** (`it`) — Duux's website and app seems to supports EN/NL/FR/ES/DE/IT, all are now covered

> `daae1b0` and `71d4ec7` are duplicate commits of the same fix, safe to squash