### PR TITLE
fix: handle null googleDeviceType during device discovery

### DIFF
--- a/.github/ISSUE_TEMPLATE/translation-request.yaml
+++ b/.github/ISSUE_TEMPLATE/translation-request.yaml
@@ -1,0 +1,74 @@
+name: Translation Request
+description: Request a new language, report a wrong/missing translation, or offer to contribute one.
+title: '[Translation]: <language>'
+labels:
+  - translation
+  - documentation
+  - User Reported
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping make the integration available in more languages! 🌍
+
+        **Currently supported:** English (`en`), German (`de`), Spanish (`es`), French (`fr`), Italian (`it`), Dutch (`nl`), Greek (`el`).
+
+        Translations live in [`custom_components/duux/translations`](https://github.com/SSmale/Duux-Home-Assistant/tree/master/custom_components/duux/translations), with [`en.json`](https://github.com/SSmale/Duux-Home-Assistant/blob/master/custom_components/duux/translations/en.json) as the source file to copy and translate.
+
+  - id: request_type
+    type: dropdown
+    attributes:
+      label: What are you requesting?
+      options:
+        - A brand new language
+        - A fix to an existing translation
+        - I'd like to contribute a translation myself
+    validations:
+      required: true
+
+  - id: language
+    type: input
+    attributes:
+      label: Language
+      description: Name of the language and, if known, the two-letter code Home Assistant uses for it.
+      placeholder: 'e.g. Polish - pl'
+    validations:
+      required: true
+
+  - id: incorrect_text
+    type: textarea
+    attributes:
+      label: Current text (only if reporting a wrong or missing translation)
+      description: Paste the existing string and the file/key it's found in.
+      placeholder: |
+        File: translations/de.json
+        Key: entity.select.fan_speed.name
+        Current text: "..."
+    validations:
+      required: false
+
+  - id: suggested_text
+    type: textarea
+    attributes:
+      label: Suggested translation
+      description: Paste your suggested text, or a full translated JSON file based on en.json.
+      render: json
+    validations:
+      required: false
+
+  - id: confirm
+    type: checkboxes
+    attributes:
+      label: Checks
+      options:
+        - label: I've checked the translations folder above to confirm this language isn't already supported
+        - label: I'm a native or fluent speaker of this language
+        - label: I'm willing to help review or test this translation
+
+  - id: additional_context
+    type: textarea
+    attributes:
+      label: Additional context
+      description: Anything else that would help — links, screenshots of mistranslated UI, etc.
+    validations:
+      required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.13.0-pre-97.1](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.12.0...v2.13.0-pre-97.1) (2026-06-19)
+
+### Added
+
+* add Greek translations ([#97](https://github.com/SSmale/Duux-Home-Assistant/issues/97)) ([ea07503](https://github.com/SSmale/Duux-Home-Assistant/commit/ea07503904600c02c65f839b62f691f65850d72f))
+
 ## [2.12.0](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.11.2...v2.12.0) (2026-06-19)
 
 ### Added
@@ -258,6 +264,7 @@ All notable changes to this project will be documented in this file.
 * [ ] Support for Duux fans
 * [ ] Local API support (if available)
 * [ ] Energy dashboard integration
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.13.0](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.12.0...v2.13.0) (2026-06-19)
+
+### Added
+
+* add Greek translations ([#97](https://github.com/SSmale/Duux-Home-Assistant/issues/97)) ([#98](https://github.com/SSmale/Duux-Home-Assistant/issues/98)) ([f3fce19](https://github.com/SSmale/Duux-Home-Assistant/commit/f3fce198f8719f605d09c99edd24aaf1566006d2))
+
 ## [2.13.0-pre-97.1](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.12.0...v2.13.0-pre-97.1) (2026-06-19)
 
 ### Added
@@ -264,6 +270,7 @@ All notable changes to this project will be documented in this file.
 * [ ] Support for Duux fans
 * [ ] Local API support (if available)
 * [ ] Energy dashboard integration
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Currently the project has translations for:
 - Italian
 - Dutch
 - Spanish
+- Greek
 
 If you spot an issue with the translations, or want to create one for another language please open an issue!
 

--- a/custom_components/duux/__init__.py
+++ b/custom_components/duux/__init__.py
@@ -53,12 +53,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Create coordinator for each device
     coordinators = {}
     for device in devices:
+        sensor_type = device.get("sensorType") or {}
         sensor_type_id = device.get("sensorTypeId")
-        device_type_id = device.get("sensorType").get("type")
-        google_type = device.get("sensorType").get("googleDeviceType")
-        last_word = google_type.split(".")[-1]  # "HEATER" OR ""THERMOSTAT"
+        device_type_id = sensor_type.get("type")
+        google_type = sensor_type.get("googleDeviceType") or ""
+        last_word = google_type.split(".")[-1] if google_type else ""  # "HEATER" OR "THERMOSTAT"
         device_name = device.get("displayName") or device.get("name")
-        model = device.get("sensorType", {}).get("name", "Unknown")
+        model = sensor_type.get("name", "Unknown")
 
         if device.get("connectionType") != "mqtt":
             _LOGGER.warning(

--- a/custom_components/duux/climate.py
+++ b/custom_components/duux/climate.py
@@ -45,18 +45,19 @@ async def async_setup_entry(
 
     entities = []
     for device in devices:
-        device_type_id = device.get("sensorType").get("type")
-        google_type = device.get("sensorType").get("googleDeviceType")
-        last_word = google_type.split(".")[-1]  # "HEATER" OR ""THERMOSTAT"
+        sensor_type = device.get("sensorType") or {}
+        device_type_id = sensor_type.get("type")
+        google_type = sensor_type.get("googleDeviceType") or ""
+        last_word = google_type.split(".")[-1] if google_type else ""  # "HEATER" OR "THERMOSTAT"
         sensor_type_id = device.get("sensorTypeId")
         device_id = device["deviceId"]
-        coordinator = coordinator = coordinators.get(device_id)
+        coordinator = coordinators.get(device_id)
 
         # Skip devices that have no coordinator (were filtered out in __init__)
         if coordinator is None:
             continue
 
-        model = device.get("sensorType", {}).get("name", "Unknown")
+        model = sensor_type.get("name", "Unknown")
 
         if device_type_id not in [*DUUX_DTID_HEATER, *DUUX_DTID_THERMOSTAT]:
             if last_word in DUUX_CLIMATE_TYPES:

--- a/custom_components/duux/fan.py
+++ b/custom_components/duux/fan.py
@@ -56,7 +56,7 @@ async def async_setup_entry(
         sensor_type = device.get("sensorType") or {}
         device_type_id = sensor_type.get("type")
         google_type = sensor_type.get("googleDeviceType") or ""
-        last_word = google_type.split(".")[-1]  # "FAN", "HEATER", etc.
+        last_word = google_type.split(".")[-1] if google_type else ""  # "HEATER" OR "THERMOSTAT"
         sensor_type_id = device.get("sensorTypeId")
         device_id = device.get("deviceId")
         coordinator = coordinators.get(device_id)

--- a/custom_components/duux/manifest.json
+++ b/custom_components/duux/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "requests>=2.31.0"
   ],
-  "version": "2.12.0"
+  "version": "2.13.0-pre-97.1"
 }

--- a/custom_components/duux/manifest.json
+++ b/custom_components/duux/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "requests>=2.31.0"
   ],
-  "version": "2.13.0-pre-97.1"
+  "version": "2.13.0"
 }

--- a/custom_components/duux/translations/el.json
+++ b/custom_components/duux/translations/el.json
@@ -1,0 +1,118 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Αυτός ο λογαριασμός Duux έχει ήδη ρυθμιστεί."
+        },
+        "error": {
+            "invalid_auth": "Μη έγκυρα στοιχεία σύνδεσης. Ελέγξτε το email και τον κωδικό πρόσβασής σας."
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "email": "Διεύθυνση email",
+                    "password": "Κωδικός πρόσβασης"
+                },
+                "description": "Εισάγετε τα στοιχεία σύνδεσης του λογαριασμού Duux.",
+                "title": "Σύνδεση Duux"
+            }
+        }
+    },
+    "entity": {
+        "binary_sensor": {
+            "connected": {
+                "name": "Συνδεδεμένο"
+            },
+            "problem": {
+                "name": "Πρόβλημα"
+            }
+        },
+        "select": {
+            "fan_speed": {
+                "name": "Ταχύτητα ανεμιστήρα"
+            },
+            "horizontal_swing": {
+                "name": "Οριζόντια κίνηση"
+            },
+            "spray_volume": {
+                "name": "Ένταση ψεκασμού"
+            },
+            "timer": {
+                "name": "Χρονοδιακόπτης"
+            },
+            "vertical_swing": {
+                "name": "Κάθετη κίνηση"
+            }
+        },
+        "sensor": {
+            "air_quality_index": {
+                "name": "Δείκτης ποιότητας αέρα",
+                "state": {
+                    "excellent": "Άριστη",
+                    "fair": "Μέτρια",
+                    "good": "Καλή",
+                    "harmful": "Επιβλαβής",
+                    "poor": "Κακή",
+                    "very_good": "Πολύ καλή"
+                }
+            },
+            "connection_type": {
+                "name": "Τύπος σύνδεσης",
+                "state": {
+                    "mqtt": "MQTT",
+                    "tcp": "TCP"
+                }
+            },
+            "error_message": {
+                "name": "Μήνυμα σφάλματος"
+            },
+            "filter_life": {
+                "name": "Υπολειπόμενη διάρκεια ζωής φίλτρου HEPA"
+            },
+            "pm25": {
+                "name": "PM2.5"
+            },
+            "time_remaining": {
+                "name": "Υπολειπόμενος χρόνος"
+            },
+            "tvoc": {
+                "name": "TVOC",
+                "state": {
+                    "acceptable": "Αποδεκτή",
+                    "harmful": "Επικίνδυνη",
+                    "healthy": "Καλή",
+                    "polluted": "Μολυσμένη"
+                }
+            }
+        },
+        "switch": {
+            "child_lock": {
+                "name": "Κλείδωμα ασφαλείας"
+            },
+            "cleaning_mode": {
+                "name": "Λειτουργία καθαρισμού"
+            },
+            "ionizer": {
+                "name": "Ιονιστής"
+            },
+            "laundry_mode": {
+                "name": "Λειτουργία στεγνώματος ρούχων"
+            },
+            "night_mode": {
+                "name": "Νυχτερινή λειτουργία"
+            },
+            "sleep_mode": {
+                "name": "Λειτουργία ύπνου"
+            }
+        }
+    },
+    "issues": {
+        "device_not_mqtt": {
+            "description": "Η Duux εντόπισε μια συσκευή που δεν είναι συνδεδεμένη μέσω MQTT. \n\rΟρισμένες λειτουργίες ενδέχεται να μην δουλεύουν.\n\rΑυτό μπορεί να διορθωθεί αποσυνδέοντας τη συσκευή από το ρεύμα για 10 δευτερόλεπτα. \n\rΌνομα συσκευής: {device_name}",
+            "title": "Η συσκευή δεν είναι συνδεδεμένη μέσω MQTT"
+        },
+        "device_not_recognised": {
+            "description": "Η Duux εντόπισε μια συσκευή που δεν υποστηρίζεται επίσημα. \n\rΕλέγξτε τον τύπο της συσκευής και αναφέρετέ το στον προγραμματιστή της ενσωμάτωσης. \n\rΤα απαραίτητα στοιχεία είναι: \n\rΌνομα συσκευής: {device_name}\n\rDevice Type ID: {device_type_id}\n\rSensor Type ID: {sensor_type_id}\n\rΤύπος συσκευής: {reported_type}.",
+            "title": "Η συσκευή δεν αναγνωρίστηκε"
+        }
+    }
+}


### PR DESCRIPTION
Fix a crash during device discovery when `googleDeviceType` is `null`.

Some Duux devices expose a null `googleDeviceType`, causing the integration to raise an `AttributeError` when calling:

```python
google_type.split(".")
```