### PR TITLE
fix: rename min/max params in set_speed to avoid shadowing builtins

### DIFF
--- a/custom_components/duux/duux_api.py
+++ b/custom_components/duux/duux_api.py
@@ -112,8 +112,9 @@ class DuuxAPI:
         """Set purifier speed (0=Auto, 1-4=Speed)."""
         return self.set_speed(device_mac, speed, 0, 4)
 
-    def set_speed(self, device_mac, speed, min, max):
-        speed = max(min, min(max, int(speed)))
+    def set_speed(self, device_mac, speed, min_speed, max_speed):
+        """Set device speed, clamped to [min_speed, max_speed]."""
+        speed = max(min_speed, min(max_speed, int(speed)))
         return self.send_command(device_mac, f"tune set speed {speed}")
 
     def set_humidity(self, device_mac, humidity):


### PR DESCRIPTION
set_speed(device_mac, speed, min, max) shadowed the built-in min()/max() functions with its own parameters, so the clamp line `speed = max(min, min(max, int(speed)))` tried to call an int as a function and raised TypeError on every invocation.

This broke set_fan_speed(), set_purifier_speed() (DuuxAirPurifierFan speed control), the base DuuxFan.async_set_percentage (Whisper Flex fans), and DuuxNeoSpeedSelector -> every speed change on a fan,
purifier, or the Neo's spray volume 