### PR TITLE
fix: prevent UnboundLocalError in async_set_preset_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.14.3](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.14.2...v2.14.3) (2026-06-20)
+
+### Fixed
+
+* correct default value handling in current_option ([#102](https://github.com/SSmale/Duux-Home-Assistant/issues/102)) ([#108](https://github.com/SSmale/Duux-Home-Assistant/issues/108)) ([f3deaff](https://github.com/SSmale/Duux-Home-Assistant/commit/f3deaff9656b1e13cecf32495757a75a9945f099))
+
 ## [2.14.3-pre-102.1](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.14.2...v2.14.3-pre-102.1) (2026-06-20)
 
 ### Fixed
@@ -329,4 +335,5 @@ All notable changes to this project will be documented in this file.
 * [ ] Add sensor entities for power consumption
 * [ ] Local API support (if available)
 * [ ] Energy dashboard integration
+
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.14.1](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.14.0...v2.14.1) (2026-06-20)
+
+### Fixed
+
+* fixes the flashing of the cards ([#84](https://github.com/SSmale/Duux-Home-Assistant/issues/84)) ([#103](https://github.com/SSmale/Duux-Home-Assistant/issues/103)) ([4461577](https://github.com/SSmale/Duux-Home-Assistant/commit/446157781287dd70b6efe3a6265eda1c84722747))
+
 ## [2.14.1-beta.1](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.14.0...v2.14.1-beta.1) (2026-06-20)
 
 ### Fixed
@@ -306,6 +312,7 @@ All notable changes to this project will be documented in this file.
 * [ ] Support for Duux fans
 * [ ] Local API support (if available)
 * [ ] Energy dashboard integration
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.14.2-pre-95.1](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.14.1...v2.14.2-pre-95.1) (2026-06-20)
+
+### Fixed
+
+* adds in swing and tilt for ultimate fan ([d7c7e91](https://github.com/SSmale/Duux-Home-Assistant/commit/d7c7e91b8376390270ec440a6df0da86874bb3da))
+* fixes variable type for power controls ([52fb0ed](https://github.com/SSmale/Duux-Home-Assistant/commit/52fb0ed7031bf5bcab4edde7bdb22cfea5796b54))
+
 ## [2.14.1](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.14.0...v2.14.1) (2026-06-20)
 
 ### Fixed
@@ -312,7 +319,6 @@ All notable changes to this project will be documented in this file.
 * [ ] Support for Duux fans
 * [ ] Local API support (if available)
 * [ ] Energy dashboard integration
-
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.14.0](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.13.2...v2.14.0) (2026-06-19)
+
+### Added
+
+* allows users to delete devices ([#85](https://github.com/SSmale/Duux-Home-Assistant/issues/85)) ([9503930](https://github.com/SSmale/Duux-Home-Assistant/commit/9503930ff4390ae4865b69a1a26321fa1b2f15c1))
+
 ## [2.13.2](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.13.1...v2.13.2) (2026-06-19)
 
 ### Fixed
@@ -294,6 +300,7 @@ All notable changes to this project will be documented in this file.
 * [ ] Support for Duux fans
 * [ ] Local API support (if available)
 * [ ] Energy dashboard integration
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.14.2](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.14.1...v2.14.2) (2026-06-20)
+
+### Fixed
+
+* adds in swing and tilt for ultimate fan ([#95](https://github.com/SSmale/Duux-Home-Assistant/issues/95)) ([8a6d288](https://github.com/SSmale/Duux-Home-Assistant/commit/8a6d2883f1f9b5f76b647e0ec7bb13e5b7267975))
+
 ## [2.14.2-pre-95.1](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.14.1...v2.14.2-pre-95.1) (2026-06-20)
 
 ### Fixed
@@ -319,6 +325,7 @@ All notable changes to this project will be documented in this file.
 * [ ] Support for Duux fans
 * [ ] Local API support (if available)
 * [ ] Energy dashboard integration
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.14.3-pre-102.1](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.14.2...v2.14.3-pre-102.1) (2026-06-20)
+
+### Fixed
+
+* correct default value handling in current_option ([#102](https://github.com/SSmale/Duux-Home-Assistant/issues/102)) ([8225faa](https://github.com/SSmale/Duux-Home-Assistant/commit/8225faa0828cea5a7566d969b76d1304723bccec))
+
 ## [2.14.2](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.14.1...v2.14.2) (2026-06-20)
 
 ### Fixed
@@ -320,15 +326,7 @@ All notable changes to this project will be documented in this file.
 
 ## Future Plans
 
-* [ ] Add switch entities for lock and timer
 * [ ] Add sensor entities for power consumption
-* [ ] Support for Duux fans
 * [ ] Local API support (if available)
 * [ ] Energy dashboard integration
-
-
-
-
-
-
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.14.1-beta.1](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.14.0...v2.14.1-beta.1) (2026-06-20)
+
+### Fixed
+
+* fixes the flashing of the cards ([#84](https://github.com/SSmale/Duux-Home-Assistant/issues/84)) ([df9c3bd](https://github.com/SSmale/Duux-Home-Assistant/commit/df9c3bde4739daa95c7657988b1c79ef3eedc03f))
+
 ## [2.14.0](https://github.com/SSmale/Duux-Home-Assistant/compare/v2.13.2...v2.14.0) (2026-06-19)
 
 ### Added
@@ -300,6 +306,7 @@ All notable changes to this project will be documented in this file.
 * [ ] Support for Duux fans
 * [ ] Local API support (if available)
 * [ ] Energy dashboard integration
+
 
 
 

--- a/custom_components/duux/__init__.py
+++ b/custom_components/duux/__init__.py
@@ -6,18 +6,19 @@ from datetime import timedelta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
-
+from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
     DOMAIN,
     DUUX_DTID_FAN,
     DUUX_DTID_HEATER,
-    DUUX_DTID_THERMOSTAT,
     DUUX_DTID_HUMIDIFIER,
     DUUX_DTID_AIR_PURIFIER,
     DUUX_DTID_OTHER_HEATER,
+    DUUX_DTID_THERMOSTAT,
     DUUX_SUPPORTED_TYPES,
 )
 from .duux_api import DuuxAPI
@@ -146,6 +147,37 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
+) -> bool:
+    """Remove a config entry from a device."""
+    # Get the entity registry
+    entity_registry = er.async_get(hass)
+
+    # Get all entities for this config entry
+    entities = er.async_entries_for_config_entry(entity_registry, config_entry.entry_id)
+
+    # Filter entities for this specific device
+    device_entities = [
+        entity for entity in entities if entity.device_id == device_entry.id
+    ]
+
+    for entity in device_entities:
+        _LOGGER.debug(
+            f"Removing entity {entity.entity_id} for device {device_entry.id}"
+        )
+        entity_registry.async_remove(entity.entity_id)
+
+    entities = er.async_entries_for_config_entry(entity_registry, config_entry.entry_id)
+
+    # Filter entities for this specific device
+    device_entities = [
+        entity for entity in entities if entity.device_id == device_entry.id
+    ]
+    # Allow removal only if no entities remain for this device
+    return len(device_entities) == 0
 
 
 class DuuxDataUpdateCoordinator(DataUpdateCoordinator):

--- a/custom_components/duux/__init__.py
+++ b/custom_components/duux/__init__.py
@@ -58,7 +58,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         sensor_type_id = device.get("sensorTypeId")
         device_type_id = sensor_type.get("type")
         google_type = sensor_type.get("googleDeviceType") or ""
-        last_word = google_type.split(".")[-1] if google_type else ""  # "HEATER" OR "THERMOSTAT"
+        last_word = (
+            google_type.split(".")[-1] if google_type else ""
+        )  # "HEATER" OR "THERMOSTAT"
         device_name = device.get("displayName") or device.get("name")
         model = sensor_type.get("name", "Unknown")
 
@@ -95,8 +97,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 learn_more_url=f"https://github.com/SSmale/Duux-Home-Assistant/issues/new?template=device_not_supported.yaml&title=Device+not+recognised+-+{model}&device_name={model}&device_type_id={device_type_id}&sensor_type_id={sensor_type_id}&reported_type={google_type}",
                 translation_placeholders={
                     "device_name": model,
-                    "device_type_id": device_type_id,
-                    "sensor_type_id": sensor_type_id,
+                    "device_type_id": str(device_type_id),
+                    "sensor_type_id": str(sensor_type_id),
                     "reported_type": google_type,
                 },
             )

--- a/custom_components/duux/climate.py
+++ b/custom_components/duux/climate.py
@@ -45,19 +45,18 @@ async def async_setup_entry(
 
     entities = []
     for device in devices:
-        sensor_type = device.get("sensorType") or {}
-        device_type_id = sensor_type.get("type")
-        google_type = sensor_type.get("googleDeviceType") or ""
-        last_word = google_type.split(".")[-1] if google_type else ""  # "HEATER" OR "THERMOSTAT"
+        device_type_id = device.get("sensorType").get("type")
+        google_type = device.get("sensorType").get("googleDeviceType")
+        last_word = google_type.split(".")[-1]  # "HEATER" OR ""THERMOSTAT"
         sensor_type_id = device.get("sensorTypeId")
         device_id = device["deviceId"]
-        coordinator = coordinators.get(device_id)
+        coordinator = coordinator = coordinators.get(device_id)
 
         # Skip devices that have no coordinator (were filtered out in __init__)
         if coordinator is None:
             continue
 
-        model = sensor_type.get("name", "Unknown")
+        model = device.get("sensorType", {}).get("name", "Unknown")
 
         if device_type_id not in [*DUUX_DTID_HEATER, *DUUX_DTID_THERMOSTAT]:
             if last_word in DUUX_CLIMATE_TYPES:
@@ -320,13 +319,17 @@ class DuuxClimateAutoDiscovery(DuuxClimate):
 
     async def async_set_preset_mode(self, preset_mode):
         """Set preset mode."""
-        for preset in self._presets:
-            if preset["name"] == preset_mode:
-                mode_command = preset["command"]
-                break
+        preset = next(
+            (p for p in self._presets if p["name"] == preset_mode), None
+        )
+        if preset is None:
+            _LOGGER.warning(
+                "%s: unknown preset mode '%s'", self._attr_name, preset_mode
+            )
+            return
 
         await self.hass.async_add_executor_job(
-            self._api.send_command, self._device_mac, f"tune set {mode_command}"
+            self._api.send_command, self._device_mac, f"tune set {preset['command']}"
         )
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/duux/climate.py
+++ b/custom_components/duux/climate.py
@@ -45,18 +45,21 @@ async def async_setup_entry(
 
     entities = []
     for device in devices:
-        device_type_id = device.get("sensorType").get("type")
-        google_type = device.get("sensorType").get("googleDeviceType")
-        last_word = google_type.split(".")[-1]  # "HEATER" OR ""THERMOSTAT"
+        sensor_type = device.get("sensorType") or {}
+        device_type_id = sensor_type.get("type")
+        google_type = sensor_type.get("googleDeviceType") or ""
+        last_word = (
+            google_type.split(".")[-1] if google_type else ""
+        )  # "HEATER" OR "THERMOSTAT"
         sensor_type_id = device.get("sensorTypeId")
         device_id = device["deviceId"]
-        coordinator = coordinator = coordinators.get(device_id)
+        coordinator = coordinators.get(device_id)
 
         # Skip devices that have no coordinator (were filtered out in __init__)
         if coordinator is None:
             continue
 
-        model = device.get("sensorType", {}).get("name", "Unknown")
+        model = sensor_type.get("name", "Unknown")
 
         if device_type_id not in [*DUUX_DTID_HEATER, *DUUX_DTID_THERMOSTAT]:
             if last_word in DUUX_CLIMATE_TYPES:
@@ -173,7 +176,9 @@ class DuuxClimate(CoordinatorEntity, ClimateEntity):
             await self.hass.async_add_executor_job(
                 self._api.set_temperature, self._device_mac, temperature
             )
-            await self.coordinator.async_request_refresh()
+            newData = self.coordinator.data
+            newData["sp"] = temperature
+            self.coordinator.async_set_updated_data(newData)
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new HVAC mode."""
@@ -186,7 +191,9 @@ class DuuxClimate(CoordinatorEntity, ClimateEntity):
             await self.hass.async_add_executor_job(
                 self._api.set_power, self._device_mac, False
             )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["power"] = 1 if hvac_mode == HVACMode.HEAT else 0
+        self.coordinator.async_set_updated_data(newData)
 
     async def async_set_preset_mode(self, preset_mode):
         """Set preset mode."""
@@ -331,7 +338,9 @@ class DuuxClimateAutoDiscovery(DuuxClimate):
         await self.hass.async_add_executor_job(
             self._api.send_command, self._device_mac, f"tune set {preset['command']}"
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["mode"] = preset["value"]
+        self.coordinator.async_set_updated_data(newData)
 
     @staticmethod
     def _deep_find(obj: Any, key: str) -> Iterator[Any]:
@@ -415,7 +424,9 @@ class DuuxEdgeTwoClimate(DuuxClimate):
         await self.hass.async_add_executor_job(
             self._api.set_mode, self._device_mac, mode
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["heatin"] = int(mode)
+        self.coordinator.async_set_updated_data(newData)
 
 
 class DuuxEdgeClimate(DuuxClimate):
@@ -458,4 +469,6 @@ class DuuxEdgeClimate(DuuxClimate):
         await self.hass.async_add_executor_job(
             self._api.set_mode, self._device_mac, mode
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["heatin"] = int(mode)
+        self.coordinator.async_set_updated_data(newData)

--- a/custom_components/duux/climate.py
+++ b/custom_components/duux/climate.py
@@ -48,7 +48,9 @@ async def async_setup_entry(
         sensor_type = device.get("sensorType") or {}
         device_type_id = sensor_type.get("type")
         google_type = sensor_type.get("googleDeviceType") or ""
-        last_word = google_type.split(".")[-1] if google_type else ""  # "HEATER" OR "THERMOSTAT"
+        last_word = (
+            google_type.split(".")[-1] if google_type else ""
+        )  # "HEATER" OR "THERMOSTAT"
         sensor_type_id = device.get("sensorTypeId")
         device_id = device["deviceId"]
         coordinator = coordinators.get(device_id)
@@ -174,7 +176,9 @@ class DuuxClimate(CoordinatorEntity, ClimateEntity):
             await self.hass.async_add_executor_job(
                 self._api.set_temperature, self._device_mac, temperature
             )
-            await self.coordinator.async_request_refresh()
+            newData = self.coordinator.data
+            newData["sp"] = temperature
+            self.coordinator.async_set_updated_data(newData)
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new HVAC mode."""
@@ -187,7 +191,9 @@ class DuuxClimate(CoordinatorEntity, ClimateEntity):
             await self.hass.async_add_executor_job(
                 self._api.set_power, self._device_mac, False
             )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["power"] = 1 if hvac_mode == HVACMode.HEAT else 0
+        self.coordinator.async_set_updated_data(newData)
 
     async def async_set_preset_mode(self, preset_mode):
         """Set preset mode."""
@@ -320,15 +326,19 @@ class DuuxClimateAutoDiscovery(DuuxClimate):
 
     async def async_set_preset_mode(self, preset_mode):
         """Set preset mode."""
+        mode_value = None
         for preset in self._presets:
             if preset["name"] == preset_mode:
                 mode_command = preset["command"]
+                mode_value = preset["value"]
                 break
 
         await self.hass.async_add_executor_job(
             self._api.send_command, self._device_mac, f"tune set {mode_command}"
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["mode"] = mode_value
+        self.coordinator.async_set_updated_data(newData)
 
     @staticmethod
     def _deep_find(obj: Any, key: str) -> Iterator[Any]:
@@ -412,7 +422,9 @@ class DuuxEdgeTwoClimate(DuuxClimate):
         await self.hass.async_add_executor_job(
             self._api.set_mode, self._device_mac, mode
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["heatin"] = int(mode)
+        self.coordinator.async_set_updated_data(newData)
 
 
 class DuuxEdgeClimate(DuuxClimate):
@@ -455,4 +467,6 @@ class DuuxEdgeClimate(DuuxClimate):
         await self.hass.async_add_executor_job(
             self._api.set_mode, self._device_mac, mode
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["heatin"] = int(mode)
+        self.coordinator.async_set_updated_data(newData)

--- a/custom_components/duux/duux_api.py
+++ b/custom_components/duux/duux_api.py
@@ -188,3 +188,13 @@ class DuuxAPI:
         """Set vertical oscillation (0=off, 1=45°, 2=100°)."""
         value = max(0, min(2, int(value)))
         return self.send_command(device_mac, f"tune set verosc {value}")
+
+    def set_swing(self, device_mac, value):
+        """Set swing level (0=off, 1=30°, 2=60°, 3=90°)."""
+        value = max(0, min(3, int(value)))
+        return self.send_command(device_mac, f"tune set swing {value}")
+
+    def set_tilt(self, device_mac, value):
+        """Set vertical tilt (0=off, 1=45°, 2=100°)."""
+        value = max(0, min(2, int(value)))
+        return self.send_command(device_mac, f"tune set tilt {value}")

--- a/custom_components/duux/fan.py
+++ b/custom_components/duux/fan.py
@@ -184,7 +184,9 @@ class DuuxFan(CoordinatorEntity, FanEntity):
     ) -> None:
         """Turn on the fan."""
         await self.hass.async_add_executor_job(self._api.set_power, self._device_mac, 1)
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["power"] = 1
+        self.coordinator.async_set_updated_data(newData)
 
         if percentage is not None:
             await self.async_set_percentage(percentage)
@@ -192,12 +194,12 @@ class DuuxFan(CoordinatorEntity, FanEntity):
         if preset_mode is not None:
             await self.async_set_preset_mode(preset_mode)
 
-        await self.coordinator.async_request_refresh()
-
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off."""
         await self.hass.async_add_executor_job(self._api.set_power, self._device_mac, 0)
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["power"] = 0
+        self.coordinator.async_set_updated_data(newData)
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
@@ -214,7 +216,9 @@ class DuuxFan(CoordinatorEntity, FanEntity):
                 self._speed_range[0],
                 self._speed_range[-1],
             )
-            await self.coordinator.async_request_refresh()
+            newData = self.coordinator.data
+            newData["speed"] = speed
+            self.coordinator.async_set_updated_data(newData)
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
@@ -231,7 +235,9 @@ class DuuxFan(CoordinatorEntity, FanEntity):
             await self.hass.async_add_executor_job(
                 self._api.set_mode, self._device_mac, mode_value
             )
-            await self.coordinator.async_request_refresh()
+            newData = self.coordinator.data
+            newData["mode"] = mode_value
+            self.coordinator.async_set_updated_data(newData)
 
 
 class DuuxWhisperFlexTwoFan(DuuxFan):
@@ -487,7 +493,9 @@ class DuuxFanAutoDiscovery(DuuxFan):
         await self.hass.async_add_executor_job(
             self._api.send_command, self._device_mac, command
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["speed"] = speed
+        self.coordinator.async_set_updated_data(newData)
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set preset mode by label."""
@@ -500,7 +508,9 @@ class DuuxFanAutoDiscovery(DuuxFan):
         await self.hass.async_add_executor_job(
             self._api.send_command, self._device_mac, preset["command"]
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["mode"] = preset["value"]
+        self.coordinator.async_set_updated_data(newData)
 
     @staticmethod
     def _deep_find(obj: Any, key: str) -> Iterator[Any]:
@@ -589,26 +599,33 @@ class DuuxAirPurifierFan(DuuxFan):
             self._api.set_purifier_speed, self._device_mac, speed
         )
 
+        newData = self.coordinator.data
+        newData["speed"] = speed
+
         # Constraint: Ionizer must be OFF if speed is at lowest (1)
-        if speed == 1 and (self.coordinator.data or {}).get("ion") == 1:
+        if speed == 1 and newData.get("ion") == 1:
             await self.hass.async_add_executor_job(
                 self._api.set_ionizer, self._device_mac, False
             )
+            newData["ion"] = 0
 
-        await self.coordinator.async_request_refresh()
+        self.coordinator.async_set_updated_data(newData)
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
         if preset_mode == "Auto":
+            newData = self.coordinator.data
             # Ensure power is ON before sending mode command
             if not self.is_on:
                 await self.hass.async_add_executor_job(
                     self._api.set_power, self._device_mac, True
                 )
+                newData["power"] = 1
             await self.hass.async_add_executor_job(
                 self._api.set_purifier_speed, self._device_mac, 0
             )
-        await self.coordinator.async_request_refresh()
+            newData["speed"] = 0
+            self.coordinator.async_set_updated_data(newData)
 
     async def async_turn_on(
         self,
@@ -625,11 +642,15 @@ class DuuxAirPurifierFan(DuuxFan):
             await self.hass.async_add_executor_job(
                 self._api.set_power, self._device_mac, True
             )
-            await self.coordinator.async_request_refresh()
+            newData = self.coordinator.data
+            newData["power"] = 1
+            self.coordinator.async_set_updated_data(newData)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
         await self.hass.async_add_executor_job(
             self._api.set_power, self._device_mac, False
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["power"] = 0
+        self.coordinator.async_set_updated_data(newData)

--- a/custom_components/duux/fan.py
+++ b/custom_components/duux/fan.py
@@ -56,7 +56,9 @@ async def async_setup_entry(
         sensor_type = device.get("sensorType") or {}
         device_type_id = sensor_type.get("type")
         google_type = sensor_type.get("googleDeviceType") or ""
-        last_word = google_type.split(".")[-1] if google_type else ""  # "HEATER" OR "THERMOSTAT"
+        last_word = (
+            google_type.split(".")[-1] if google_type else ""
+        )  # "HEATER" OR "THERMOSTAT"
         sensor_type_id = device.get("sensorTypeId")
         device_id = device.get("deviceId")
         coordinator = coordinators.get(device_id)
@@ -183,9 +185,11 @@ class DuuxFan(CoordinatorEntity, FanEntity):
         **kwargs: Any,
     ) -> None:
         """Turn on the fan."""
-        await self.hass.async_add_executor_job(self._api.set_power, self._device_mac, 1)
+        await self.hass.async_add_executor_job(
+            self._api.set_power, self._device_mac, True
+        )
         newData = self.coordinator.data
-        newData["power"] = 1
+        newData["power"] = True
         self.coordinator.async_set_updated_data(newData)
 
         if percentage is not None:
@@ -196,9 +200,11 @@ class DuuxFan(CoordinatorEntity, FanEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off."""
-        await self.hass.async_add_executor_job(self._api.set_power, self._device_mac, 0)
+        await self.hass.async_add_executor_job(
+            self._api.set_power, self._device_mac, False
+        )
         newData = self.coordinator.data
-        newData["power"] = 0
+        newData["power"] = False
         self.coordinator.async_set_updated_data(newData)
 
     async def async_set_percentage(self, percentage: int) -> None:

--- a/custom_components/duux/humidifier.py
+++ b/custom_components/duux/humidifier.py
@@ -1,7 +1,6 @@
 """Support for Duux de/humidifier devices."""
 
 import logging
-import asyncio
 
 from homeassistant.components.humidifier import HumidifierDeviceClass, HumidifierEntity
 from homeassistant.components.humidifier.const import (
@@ -118,13 +117,17 @@ class DuuxBase(CoordinatorEntity, HumidifierEntity):
         await self.hass.async_add_executor_job(
             self._api.set_power, self._device_mac, True
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["power"] = 1
+        self.coordinator.async_set_updated_data(newData)
 
     async def async_turn_off(self, **kwargs):
         await self.hass.async_add_executor_job(
             self._api.set_power, self._device_mac, False
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["power"] = 0
+        self.coordinator.async_set_updated_data(newData)
 
     @property
     def is_on(self):
@@ -152,7 +155,9 @@ class DuuxBase(CoordinatorEntity, HumidifierEntity):
         await self.hass.async_add_executor_job(
             self._api.set_humidity, self._device_mac, humidity
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["sp"] = humidity
+        self.coordinator.async_set_updated_data(newData)
 
     @property
     def should_poll(self):
@@ -247,7 +252,9 @@ class DuuxBoraDehumidifier(DuuxDehumidifier):
         await self.hass.async_add_executor_job(
             self._api.set_dry_mode, self._device_mac, mode
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["mode"] = int(mode)
+        self.coordinator.async_set_updated_data(newData)
 
 
 class DuuxBeamMiniDehumidifier(DuuxHumidifier):
@@ -288,7 +295,9 @@ class DuuxBeamMiniDehumidifier(DuuxHumidifier):
         await self.hass.async_add_executor_job(
             self._api.set_dry_mode, self._device_mac, mode
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["mode"] = int(mode)
+        self.coordinator.async_set_updated_data(newData)
 
 
 class DuuxNeoHumidifier(DuuxDehumidifier):
@@ -353,9 +362,9 @@ class DuuxNeoHumidifier(DuuxDehumidifier):
             self._device_mac,
             api_mode,
         )
-        # Pause to allow the Duux cloud to process the change
-        await asyncio.sleep(2)
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["mode"] = api_mode
+        self.coordinator.async_set_updated_data(newData)
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/duux/manifest.json
+++ b/custom_components/duux/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "requests>=2.31.0"
   ],
-  "version": "2.14.3-pre-102.1"
+  "version": "2.14.3"
 }

--- a/custom_components/duux/manifest.json
+++ b/custom_components/duux/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "requests>=2.31.0"
   ],
-  "version": "2.14.2"
+  "version": "2.14.3-pre-102.1"
 }

--- a/custom_components/duux/manifest.json
+++ b/custom_components/duux/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "requests>=2.31.0"
   ],
-  "version": "2.14.1-beta.1"
+  "version": "2.14.1"
 }

--- a/custom_components/duux/manifest.json
+++ b/custom_components/duux/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "requests>=2.31.0"
   ],
-  "version": "2.13.2"
+  "version": "2.14.0"
 }

--- a/custom_components/duux/manifest.json
+++ b/custom_components/duux/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "requests>=2.31.0"
   ],
-  "version": "2.14.1"
+  "version": "2.14.2-pre-95.1"
 }

--- a/custom_components/duux/manifest.json
+++ b/custom_components/duux/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "requests>=2.31.0"
   ],
-  "version": "2.14.2-pre-95.1"
+  "version": "2.14.2"
 }

--- a/custom_components/duux/manifest.json
+++ b/custom_components/duux/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "requests>=2.31.0"
   ],
-  "version": "2.14.0"
+  "version": "2.14.1-beta.1"
 }

--- a/custom_components/duux/select.py
+++ b/custom_components/duux/select.py
@@ -79,10 +79,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             entities.append(DuuxTimerSelector(coordinator, api, device))
 
         if coordinator.data.get("horosc") is not None:
-            entities.append(DuuxHorizontalSwingSelect(coordinator, api, device))
+            entities.append(DuuxHorizontalOscillationSelect(coordinator, api, device))
 
         if coordinator.data.get("verosc") is not None:
-            entities.append(DuuxVerticalSwingSelect(coordinator, api, device))
+            entities.append(DuuxVerticalOscillationSelect(coordinator, api, device))
+        if coordinator.data.get("swing") is not None:
+            entities.append(DuuxHorizontalSwingSelect(coordinator, api, device))
+
+        if coordinator.data.get("tilt") is not None:
+            entities.append(DuuxVerticalTiltSelect(coordinator, api, device))
     async_add_entities(entities)
 
 
@@ -166,8 +171,8 @@ class DuuxSwingSelect(CoordinatorEntity, SelectEntity):
         self.coordinator.async_set_updated_data(newData)
 
 
-class DuuxHorizontalSwingSelect(DuuxSwingSelect):
-    """Select entity controlling horizontal swing level."""
+class DuuxHorizontalOscillationSelect(DuuxSwingSelect):
+    """Select entity controlling horizontal oscillation level."""
 
     _options_map = HORIZONTAL_SWING_OPTIONS
     _data_key = "horosc"
@@ -183,7 +188,7 @@ class DuuxHorizontalSwingSelect(DuuxSwingSelect):
         self._attr_icon = "mdi:arrow-left-right"
 
 
-class DuuxVerticalSwingSelect(DuuxSwingSelect):
+class DuuxVerticalOscillationSelect(DuuxSwingSelect):
     """Select entity controlling vertical swing level."""
 
     _options_map = VERTICAL_SWING_OPTIONS
@@ -194,6 +199,40 @@ class DuuxVerticalSwingSelect(DuuxSwingSelect):
 
     def __init__(self, coordinator, api, device) -> None:
         """Initialize the vertical swing select."""
+        super().__init__(coordinator, api, device)
+        self._attr_unique_id = f"duux_{self._device_id}_vertical_swing"
+        self._attr_translation_key = "vertical_swing"
+        self._attr_icon = "mdi:arrow-up-down"
+
+
+class DuuxHorizontalSwingSelect(DuuxSwingSelect):
+    """Select entity controlling horizontal swing level."""
+
+    _options_map = HORIZONTAL_SWING_OPTIONS
+    _data_key = "swing"
+
+    def _set_value(self, device_mac: str, value: int):
+        return self._api.set_swing(device_mac, value)
+
+    def __init__(self, coordinator, api, device) -> None:
+        """Initialize the horizontal swing select."""
+        super().__init__(coordinator, api, device)
+        self._attr_unique_id = f"duux_{self._device_id}_horizontal_swing"
+        self._attr_translation_key = "horizontal_swing"
+        self._attr_icon = "mdi:arrow-left-right"
+
+
+class DuuxVerticalTiltSelect(DuuxSwingSelect):
+    """Select entity controlling vertical tilt level."""
+
+    _options_map = VERTICAL_SWING_OPTIONS
+    _data_key = "tilt"
+
+    def _set_value(self, device_mac: str, value: int):
+        return self._api.set_tilt(device_mac, value)
+
+    def __init__(self, coordinator, api, device) -> None:
+        """Initialize the vertical tilt select."""
         super().__init__(coordinator, api, device)
         self._attr_unique_id = f"duux_{self._device_id}_vertical_swing"
         self._attr_translation_key = "vertical_swing"

--- a/custom_components/duux/select.py
+++ b/custom_components/duux/select.py
@@ -161,7 +161,9 @@ class DuuxSwingSelect(CoordinatorEntity, SelectEntity):
         value = self._options_map[option]
 
         await self.hass.async_add_executor_job(self._set_value, self._device_mac, value)
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData[self._data_key] = value
+        self.coordinator.async_set_updated_data(newData)
 
 
 class DuuxHorizontalSwingSelect(DuuxSwingSelect):
@@ -270,7 +272,9 @@ class DuuxFanSpeedSelector(DuuxSelector):
         await self.hass.async_add_executor_job(
             self._api.set_fan, self._device_mac, mode
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["fan"] = int(mode)
+        self.coordinator.async_set_updated_data(newData)
 
 
 class DuuxTimerSelector(DuuxSelector):
@@ -300,7 +304,9 @@ class DuuxTimerSelector(DuuxSelector):
         await self.hass.async_add_executor_job(
             self._api.set_timer, self._device_mac, str(amount)
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["timer"] = amount
+        self.coordinator.async_set_updated_data(newData)
 
 
 class DuuxBright2TimerSelector(DuuxTimerSelector):
@@ -351,4 +357,6 @@ class DuuxNeoSpeedSelector(DuuxSelector):
         await self.hass.async_add_executor_job(
             self._api.set_speed, self._device_mac, mode, 0, 2
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["speed"] = int(mode)
+        self.coordinator.async_set_updated_data(newData)

--- a/custom_components/duux/select.py
+++ b/custom_components/duux/select.py
@@ -292,12 +292,12 @@ class DuuxFanSpeedSelector(DuuxSelector):
     @property
     def current_option(self):
         """Return current fan mode."""
-        mode = (self.coordinator.data or {}).get("fan", self.FAN_LOW)
+        mode = (self.coordinator.data or {}).get("fan")
         mode_map = {
             1: self.FAN_LOW,
             0: self.FAN_HIGH,
         }
-        return mode_map.get(mode)
+        return mode_map.get(mode, self.FAN_LOW)
 
     async def async_select_option(self, option):
         """Set fan speed mode."""
@@ -331,7 +331,8 @@ class DuuxTimerSelector(DuuxSelector):
     @property
     def current_option(self):
         """Return current timer."""
-        return str((self.coordinator.data or {}).get("timer"))
+        timer = (self.coordinator.data or {}).get("timer")
+        return str(timer) if timer is not None else None
 
     async def async_select_option(self, option):
         """Set timer amount."""

--- a/custom_components/duux/sensor.py
+++ b/custom_components/duux/sensor.py
@@ -71,7 +71,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         elif sensor_type_id == DUUX_STID_BEAM_MINI:
             entities.append(DuuxHumiditySensor(coordinator, api, device))
             entities.append(DuuxTempSensor(coordinator, api, device))
-        else:
+        elif coordinator.data.get("temp") is not None:
             entities.append(DuuxTempSensor(coordinator, api, device))
 
         entities.append(DuuxErrorSensor(coordinator, api, device))
@@ -122,6 +122,7 @@ class DuuxSensor(CoordinatorEntity, SensorEntity):
         self._attr_native_value = data.get(self.entity_description.key)
         self._attr_extra_state_attributes = self.entity_description.attrs(data)
         self.async_write_ha_state()
+
 
 class DuuxTempSensor(DuuxSensor):
     def __init__(self, coordinator, api, device):

--- a/custom_components/duux/switch.py
+++ b/custom_components/duux/switch.py
@@ -124,14 +124,18 @@ class DuuxChildLockSwitch(DuuxSwitch):
         await self.hass.async_add_executor_job(
             self._api.set_lock, self._device_mac, True
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["lock"] = 1
+        self.coordinator.async_set_updated_data(newData)
 
     async def async_turn_off(self, **kwargs):
         """Turn off child lock."""
         await self.hass.async_add_executor_job(
             self._api.set_lock, self._device_mac, False
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["lock"] = 0
+        self.coordinator.async_set_updated_data(newData)
 
 
 class DuuxNightModeSwitch(DuuxSwitch):
@@ -154,14 +158,18 @@ class DuuxNightModeSwitch(DuuxSwitch):
         await self.hass.async_add_executor_job(
             self._api.set_night_mode, self._device_mac, True
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["night"] = 1
+        self.coordinator.async_set_updated_data(newData)
 
     async def async_turn_off(self, **kwargs):
         """Turn off night mode."""
         await self.hass.async_add_executor_job(
             self._api.set_night_mode, self._device_mac, False
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["night"] = 0
+        self.coordinator.async_set_updated_data(newData)
 
 
 class DuuxSleepModeSwitch(DuuxSwitch):
@@ -184,14 +192,18 @@ class DuuxSleepModeSwitch(DuuxSwitch):
         await self.hass.async_add_executor_job(
             self._api.set_sleep_mode, self._device_mac, True
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["sleep"] = 1
+        self.coordinator.async_set_updated_data(newData)
 
     async def async_turn_off(self, **kwargs):
         """Turn off sleep mode."""
         await self.hass.async_add_executor_job(
             self._api.set_sleep_mode, self._device_mac, False
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["sleep"] = 0
+        self.coordinator.async_set_updated_data(newData)
 
 
 class DuuxCleaningModeSwitch(DuuxSwitch):
@@ -214,14 +226,18 @@ class DuuxCleaningModeSwitch(DuuxSwitch):
         await self.hass.async_add_executor_job(
             self._api.set_cleaning_mode, self._device_mac, True
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["dry"] = 1
+        self.coordinator.async_set_updated_data(newData)
 
     async def async_turn_off(self, **kwargs):
         """Turn off cleaning mode."""
         await self.hass.async_add_executor_job(
             self._api.set_cleaning_mode, self._device_mac, False
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["dry"] = 0
+        self.coordinator.async_set_updated_data(newData)
 
 
 class DuuxLaundryModeSwitch(DuuxSwitch):
@@ -244,14 +260,18 @@ class DuuxLaundryModeSwitch(DuuxSwitch):
         await self.hass.async_add_executor_job(
             self._api.set_laundry_mode, self._device_mac, True
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["laundr"] = 1
+        self.coordinator.async_set_updated_data(newData)
 
     async def async_turn_off(self, **kwargs):
         """Turn off Laundry mode."""
         await self.hass.async_add_executor_job(
             self._api.set_laundry_mode, self._device_mac, False
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["laundr"] = 0
+        self.coordinator.async_set_updated_data(newData)
 
 
 class DuuxIonizerSwitch(DuuxSwitch):
@@ -298,11 +318,15 @@ class DuuxIonizerSwitch(DuuxSwitch):
         await self.hass.async_add_executor_job(
             self._api.set_ionizer, self._device_mac, True
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["ion"] = 1
+        self.coordinator.async_set_updated_data(newData)
 
     async def async_turn_off(self, **kwargs):
         """Turn off ionizer."""
         await self.hass.async_add_executor_job(
             self._api.set_ionizer, self._device_mac, False
         )
-        await self.coordinator.async_request_refresh()
+        newData = self.coordinator.data
+        newData["ion"] = 0
+        self.coordinator.async_set_updated_data(newData)


### PR DESCRIPTION
**DuuxClimateAutoDiscovery**.async_set_preset_mode looped over self._presets looking for a match and only set mode_command inside the loop body. If no preset matched (eg self._presets is empty, or the requested preset_mode isn't in the discovered list), mode_command was never assigned, and the f string referencing it raised UnboundLocalError.

Now uses next() to find the match and logs a warning and returns early when nothing matches.