### PR TITLE
feat: add support for Duux North AC

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A Home Assistant integration for Duux products, allowing you to control your dev
 - 🌡️ **Temperature Control**: Set target temperature (16–31°C)
 - ❄️ **Three Modes**: Cool, Dry and Fan-only
 - 💨 **Three Fan Speeds**: I, II and III
+- 🔄 **Louver Swing**: On/off control
 - 🌙 **Night Mode**: Dim the display
 - ⏲️ **Timer**: Set a shutdown timer (0–24 hours)
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ A Home Assistant integration for Duux products, allowing you to control your dev
 
 ---
 
+### ❄️ Air Conditioners
+
+#### Duux North
+
+- ⚡ **Power**: On/Off control
+- 🌡️ **Temperature Control**: Set target temperature (16–31°C)
+- ❄️ **Three Modes**: Cool, Dry and Fan-only
+- 💨 **Three Fan Speeds**: I, II and III
+- 🌙 **Night Mode**: Dim the display
+- ⏲️ **Timer**: Set a shutdown timer (0–24 hours)
+
+---
+
 ### 💨 Fans
 
 #### Duux Whisper Flex Ultimate

--- a/custom_components/duux/__init__.py
+++ b/custom_components/duux/__init__.py
@@ -17,6 +17,7 @@ from .const import (
     DUUX_DTID_HEATER,
     DUUX_DTID_HUMIDIFIER,
     DUUX_DTID_AIR_PURIFIER,
+    DUUX_DTID_AIR_CONDITIONER,
     DUUX_DTID_OTHER_HEATER,
     DUUX_DTID_THERMOSTAT,
     DUUX_SUPPORTED_TYPES,
@@ -82,6 +83,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             *DUUX_DTID_THERMOSTAT,
             *DUUX_DTID_HUMIDIFIER,
             *DUUX_DTID_AIR_PURIFIER,
+            *DUUX_DTID_AIR_CONDITIONER,
             *DUUX_DTID_OTHER_HEATER,
             *DUUX_DTID_FAN,
         ]:

--- a/custom_components/duux/climate.py
+++ b/custom_components/duux/climate.py
@@ -234,9 +234,6 @@ class DuuxNorthClimate(DuuxClimate):
       - mode 1 -> Cool
       - mode 3 -> Dry
       - mode 4 -> Fan-only
-      - mode 2: unused, shows no icon at all
-      - 5/6/7: unused, the firmware just shows the Cool icon for any
-        unrecognised code
 
     Night-mode and Fan Speed (I/II/III) are separate entities.
     """

--- a/custom_components/duux/climate.py
+++ b/custom_components/duux/climate.py
@@ -21,12 +21,14 @@ from .const import (
     DUUX_CLIMATE_TYPES,
     DUUX_DTID_THERMOSTAT,
     DUUX_DTID_HEATER,
+    DUUX_DTID_AIR_CONDITIONER,
     DOMAIN,
     DUUX_STID_THREESIXTY_2023,
     DUUX_STID_EDGEHEATER_V2,
     DUUX_STID_EDGEHEATER_2000,
     DUUX_STID_EDGEHEATER_2023_V1,
     DUUX_STID_THREESIXTY_TWO,
+    DUUX_STID_NORTH,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -59,7 +61,11 @@ async def async_setup_entry(
 
         model = sensor_type.get("name", "Unknown")
 
-        if device_type_id not in [*DUUX_DTID_HEATER, *DUUX_DTID_THERMOSTAT]:
+        if device_type_id not in [
+            *DUUX_DTID_HEATER,
+            *DUUX_DTID_THERMOSTAT,
+            *DUUX_DTID_AIR_CONDITIONER,
+        ]:
             if last_word in DUUX_CLIMATE_TYPES:
                 _LOGGER.warning(
                     "Your device has not been officially catagorised as supporting the climate platform."
@@ -89,6 +95,10 @@ async def async_setup_entry(
             entities.append(DuuxEdgeClimate(coordinator, api, device))
         elif sensor_type_id == DUUX_STID_THREESIXTY_TWO:
             entities.append(DuuxThreesixtyTwoClimate(coordinator, api, device))
+        elif sensor_type_id == DUUX_STID_NORTH:
+            # Reports via a "Traits" schema, not "availableModes", so it
+            # can't use the generic DuuxClimateAutoDiscovery fallback below.
+            entities.append(DuuxNorthClimate(coordinator, api, device))
         else:
             # Fallback to generic entity for unknown types
             entities.append(DuuxClimateAutoDiscovery(coordinator, api, device))
@@ -214,6 +224,78 @@ class DuuxClimate(CoordinatorEntity, ClimateEntity):
 
     async def async_update(self):
         """Update the entity."""
+        await self.coordinator.async_request_refresh()
+
+
+class DuuxNorthClimate(DuuxClimate):
+    """Duux North AC (device_type_id=28, sensor_type_id=42).
+
+    Mode mapping:
+      - mode 1 -> Cool
+      - mode 3 -> Dry
+      - mode 4 -> Fan-only
+      - mode 2: unused, shows no icon at all
+      - 5/6/7: unused, the firmware just shows the Cool icon for any
+        unrecognised code
+
+    Night-mode and Fan Speed (I/II/III) are separate entities.
+    """
+
+    _MODE_TO_HVAC = {
+        1: HVACMode.COOL,
+        3: HVACMode.DRY,
+        4: HVACMode.FAN_ONLY,
+    }
+    _HVAC_TO_MODE = {v: k for k, v in _MODE_TO_HVAC.items()}
+
+    def __init__(self, coordinator, api, device):
+        """Initialize the North climate device."""
+        super().__init__(coordinator, api, device)
+        # The Traits schema says 18-30; the real app shows 16-31 instead.
+        self._attr_min_temp = 16
+        self._attr_max_temp = 31
+        self._attr_target_temperature_step = 1
+        self._attr_supported_features = (
+            ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TURN_OFF
+            | ClimateEntityFeature.TURN_ON
+        )
+        # Override base class's HEAT-based modes: no heating function,
+        # use Cool/Dry/Fan-only instead.
+        self._attr_hvac_modes = [
+            HVACMode.OFF,
+            HVACMode.COOL,
+            HVACMode.DRY,
+            HVACMode.FAN_ONLY,
+        ]
+
+    @property
+    def hvac_mode(self):
+        """Return current operation based on power + the confirmed mode mapping."""
+        data = self.coordinator.data or {}
+        if data.get("power", 0) != 1:
+            return HVACMode.OFF
+        mode = data.get("mode")
+        # Unrecognised codes fall back to Cool, matching the firmware.
+        return self._MODE_TO_HVAC.get(mode, HVACMode.COOL)
+
+    async def async_set_hvac_mode(self, hvac_mode):
+        """Turn off, or turn on + set mode together (mirrors the app's flow)."""
+        if hvac_mode == HVACMode.OFF:
+            await self.hass.async_add_executor_job(
+                self._api.set_power, self._device_mac, False
+            )
+        else:
+            await self.hass.async_add_executor_job(
+                self._api.set_power, self._device_mac, True
+            )
+            mode_value = self._HVAC_TO_MODE.get(hvac_mode)
+            if mode_value is not None:
+                await self.hass.async_add_executor_job(
+                    self._api.send_command,
+                    self._device_mac,
+                    f"tune set mode {mode_value}",
+                )
         await self.coordinator.async_request_refresh()
 
 

--- a/custom_components/duux/const.py
+++ b/custom_components/duux/const.py
@@ -26,6 +26,7 @@ DUUX_STID_WHISPER_FLEX_ULTIMATE = 40
 DUUX_STID_WHISPER_FLEX_ELIVATE = 70
 DUUX_STID_BRIGHT_2 = 61
 DUUX_STID_NEO = 47
+DUUX_STID_NORTH = 42
 
 # Device Type IDs
 DUUX_DTID_THERMOSTAT = [50]
@@ -33,6 +34,10 @@ DUUX_DTID_HEATER = [51, 52, 21, 23]
 DUUX_DTID_HUMIDIFIER = [56, 25]
 DUUX_DTID_FAN = [26, 58, 27, 59]
 DUUX_DTID_AIR_PURIFIER = [55, 32]
+
+# North AC reports googleDeviceType: null inconsistently, so it's matched
+# directly on device_type_id rather than via the last_word fallback.
+DUUX_DTID_AIR_CONDITIONER = [28]
 
 DUUX_DTID_OTHER_HEATER = []
 

--- a/custom_components/duux/duux_api.py
+++ b/custom_components/duux/duux_api.py
@@ -196,3 +196,10 @@ class DuuxAPI:
         """
         speed = max(1, min(3, int(speed)))
         return self.send_command(device_mac, f"tune set fan {speed}")
+
+    def set_louver_swing(self, device_mac, swing_on):
+        """Set the North AC's louver swing on/off via the "tilt" field
+        (not "swing", which stays unused/null on this device).
+        """
+        value = "1" if swing_on else "0"
+        return self.send_command(device_mac, f"tune set tilt {value}")

--- a/custom_components/duux/duux_api.py
+++ b/custom_components/duux/duux_api.py
@@ -188,3 +188,11 @@ class DuuxAPI:
         """Set vertical oscillation (0=off, 1=45°, 2=100°)."""
         value = max(0, min(2, int(value)))
         return self.send_command(device_mac, f"tune set verosc {value}")
+
+    def set_north_fan_speed(self, device_mac, speed):
+        """Set the North AC's fan speed (1=I, 2=II, 3=III). Same "tune
+        set fan" command as the heater's set_fan(), but with a 3-level
+        range instead of binary. Can't reuse that method directly.
+        """
+        speed = max(1, min(3, int(speed)))
+        return self.send_command(device_mac, f"tune set fan {speed}")

--- a/custom_components/duux/select.py
+++ b/custom_components/duux/select.py
@@ -17,6 +17,7 @@ from .const import (
     DUUX_STID_BRIGHT_2,
     DUUX_STID_EDGEHEATER_V2,
     DUUX_STID_NEO,
+    DUUX_STID_NORTH,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -77,6 +78,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             entities.append(DuuxBright2TimerSelector(coordinator, api, device))
         elif sensor_type_id in [DUUX_STID_BEAM_MINI, DUUX_STID_EDGEHEATER_V2]:
             entities.append(DuuxTimerSelector(coordinator, api, device))
+        elif sensor_type_id == DUUX_STID_NORTH:
+            entities.append(DuuxNorthFanSpeedSelector(coordinator, api, device))
+            # North specific Timer: also powers the unit on (matches the
+            # real app), unlike the shared DuuxTimerSelector used elsewhere.
+            entities.append(DuuxNorthTimerSelector(coordinator, api, device))
 
         if coordinator.data.get("horosc") is not None:
             entities.append(DuuxHorizontalSwingSelect(coordinator, api, device))
@@ -350,5 +356,66 @@ class DuuxNeoSpeedSelector(DuuxSelector):
 
         await self.hass.async_add_executor_job(
             self._api.set_speed, self._device_mac, mode, 0, 2
+        )
+        await self.coordinator.async_request_refresh()
+
+
+class DuuxNorthTimerSelector(DuuxTimerSelector):
+    """North-specific Timer: also powers the unit on for non-zero
+    values, matching the real app. Kept as a subclass rather than
+    changing the shared DuuxTimerSelector, since this behaviour isn't
+    confirmed for the other devices that use it (Bora/Neo/BeamMini/
+    Bright2/Edge).
+    """
+
+    async def async_select_option(self, option):
+        """Set timer amount, turning the unit on first if non-zero."""
+        try:
+            amount = max(0, min(24, int(option)))
+        except (TypeError, ValueError):
+            amount = 0
+
+        if amount > 0:
+            await self.hass.async_add_executor_job(
+                self._api.set_power, self._device_mac, True
+            )
+
+        await self.hass.async_add_executor_job(
+            self._api.set_timer, self._device_mac, str(amount)
+        )
+        await self.coordinator.async_request_refresh()
+
+
+class DuuxNorthFanSpeedSelector(DuuxSelector):
+    """Duux North AC fan speed selector. Raw "fan" values 1/2/3 map
+    directly to I/II/III, sent via set_north_fan_speed().
+    """
+
+    SPEED_I = "I"
+    SPEED_II = "II"
+    SPEED_III = "III"
+
+    _SPEED_MAP = {1: SPEED_I, 2: SPEED_II, 3: SPEED_III}
+    _LABEL_TO_RAW = {v: k for k, v in _SPEED_MAP.items()}
+
+    def __init__(self, coordinator, api, device):
+        """Initialize the fan speed selector."""
+        super().__init__(coordinator, api, device)
+        self._attr_unique_id = f"duux_{self._device_id}_fan_speed"
+        self._attr_name = "Fan Speed"
+        self._attr_icon = "mdi:fan"
+        self._attr_options = [self.SPEED_I, self.SPEED_II, self.SPEED_III]
+
+    @property
+    def current_option(self):
+        """Return current fan speed label."""
+        fan = (self.coordinator.data or {}).get("fan")
+        return self._SPEED_MAP.get(fan)
+
+    async def async_select_option(self, option):
+        """Set fan speed."""
+        raw = self._LABEL_TO_RAW.get(option, 1)
+        await self.hass.async_add_executor_job(
+            self._api.set_north_fan_speed, self._device_mac, raw
         )
         await self.coordinator.async_request_refresh()

--- a/custom_components/duux/switch.py
+++ b/custom_components/duux/switch.py
@@ -70,10 +70,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             entities.append(DuuxNightModeSwitch(coordinator, api, device))
             entities.append(DuuxIonizerSwitch(coordinator, api, device))
 
-        # North: "swing" is confirmed present in the raw status payload
-        # but parked for a future PR
+        # North
         elif sensor_type_id == DUUX_STID_NORTH:
             entities.append(DuuxNightModeSwitch(coordinator, api, device))
+            entities.append(DuuxLouverSwingSwitch(coordinator, api, device))
 
     async_add_entities(entities)
 
@@ -166,6 +166,38 @@ class DuuxNightModeSwitch(DuuxSwitch):
         """Turn off night mode."""
         await self.hass.async_add_executor_job(
             self._api.set_night_mode, self._device_mac, False
+        )
+        await self.coordinator.async_request_refresh()
+
+
+class DuuxLouverSwingSwitch(DuuxSwitch):
+    """Duux North louver swing switch. Controlled via the "tilt" field
+    (not "swing", which stays unused/null on this device)
+    """
+
+    def __init__(self, coordinator, api, device):
+        """Initialize the louver swing switch."""
+        super().__init__(coordinator, api, device)
+        self._attr_unique_id = f"duux_{self._device_id}_louver_swing"
+        self._attr_name = "Louver Swing"
+        self._attr_icon = "mdi:arrow-left-right"
+
+    @property
+    def is_on(self):
+        """Return true if louver swing is on."""
+        return (self.coordinator.data or {}).get("tilt") == 1
+
+    async def async_turn_on(self, **kwargs):
+        """Turn on louver swing."""
+        await self.hass.async_add_executor_job(
+            self._api.set_louver_swing, self._device_mac, True
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn off louver swing."""
+        await self.hass.async_add_executor_job(
+            self._api.set_louver_swing, self._device_mac, False
         )
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/duux/switch.py
+++ b/custom_components/duux/switch.py
@@ -15,6 +15,7 @@ from custom_components.duux.const import (
     DUUX_STID_WHISPER_FLEX_2,
     DUUX_STID_WHISPER_FLEX_ELIVATE,
     DUUX_STID_NEO,
+    DUUX_STID_NORTH,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -68,6 +69,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         elif sensor_type_id == DUUX_STID_BRIGHT_2:
             entities.append(DuuxNightModeSwitch(coordinator, api, device))
             entities.append(DuuxIonizerSwitch(coordinator, api, device))
+
+        # North: "swing" is confirmed present in the raw status payload
+        # but parked for a future PR
+        elif sensor_type_id == DUUX_STID_NORTH:
+            entities.append(DuuxNightModeSwitch(coordinator, api, device))
 
     async_add_entities(entities)
 

--- a/info.md
+++ b/info.md
@@ -12,6 +12,10 @@ Control your Duux devices directly from Home Assistant!
 - **Threesixty 2** — Temperature control, Eco/Comfort/Boost modes
 - **Threesixty 2023** — Temperature control, Eco/Comfort/Boost modes
 
+### ❄️ Air Conditioners
+
+- **North** — Temperature control, Cool/Dry/Fan-only modes, 3-speed fan, Night mode, Timer
+
 ### 💨 Fans
 
 - **Whisper Flex Ultimate** — 30-speed fan, Normal/Natural/Night modes

--- a/info.md
+++ b/info.md
@@ -14,7 +14,7 @@ Control your Duux devices directly from Home Assistant!
 
 ### ❄️ Air Conditioners
 
-- **North** — Temperature control, Cool/Dry/Fan-only modes, 3-speed fan, Night mode, Timer
+- **North** — Temperature control, Cool/Dry/Fan-only modes, 3-speed fan, Louver swing, Night mode, Timer
 
 ### 💨 Fans
 


### PR DESCRIPTION
Adds device recognition (device_type_id=28, sensor_type_id=42) and a new climate entity for the North, which reports via a "Traits" schema rather than the "availableModes" schema other heaters use, so it can't go through the generic DuuxClimateAutoDiscovery fallback.

- climate.py: DuuxNorthClimate with Off/Cool/Dry/Fan-only hvac_modes and temperature control (16-31°C,  the Traits schema's 18-30 doesn't match). 
Mode mapping (1=Cool, 3=Dry, 4=Fan-only) found by testing against the physical unit. Selecting a mode also powers the
unit on, matching the app's flow.
  
- select.py: Fan Speed selector (I/II/III, confirmed mapping to raw  values 1/2/3) and a North-specific Timer selector that also powers the unit on for non zero values (kept as a subclass so the shared DuuxTimerSelector used by other devices is untouched).
  
- switch.py: reuses the existing Night Mode switch.

- duux_api.py: adds set_north_fan_speed().

- const.py/__init__.py: new DUUX_DTID_AIR_CONDITIONER category,  matched directly on device_type_id since  googleDeviceType is reported inconsistently (sometimes null) for this device.

Not included: Louver swing. Two command guesses ("tune set swing" with "01"/"00" and "1"/"0") both produced no physical reaction -> needs a proper network capture against the mobile app.