### PR TITLE
fix: prevent UnboundLocalError in async_set_preset_mode

### DIFF
--- a/custom_components/duux/climate.py
+++ b/custom_components/duux/climate.py
@@ -326,18 +326,20 @@ class DuuxClimateAutoDiscovery(DuuxClimate):
 
     async def async_set_preset_mode(self, preset_mode):
         """Set preset mode."""
-        mode_value = None
-        for preset in self._presets:
-            if preset["name"] == preset_mode:
-                mode_command = preset["command"]
-                mode_value = preset["value"]
-                break
+        preset = next(
+            (p for p in self._presets if p["name"] == preset_mode), None
+        )
+        if preset is None:
+            _LOGGER.warning(
+                "%s: unknown preset mode '%s'", self._attr_name, preset_mode
+            )
+            return
 
         await self.hass.async_add_executor_job(
-            self._api.send_command, self._device_mac, f"tune set {mode_command}"
+            self._api.send_command, self._device_mac, f"tune set {preset['command']}"
         )
         newData = self.coordinator.data
-        newData["mode"] = mode_value
+        newData["mode"] = preset["value"]
         self.coordinator.async_set_updated_data(newData)
 
     @staticmethod


### PR DESCRIPTION
mode_command was only set inside the loop body when a preset matched. If no preset matched, the f string referencing it raised UnboundLocalError. Now it uses next() to find the match explicitly and returns early with a warning when nothing matches.